### PR TITLE
Add Chrome image prompt extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Image Prompt Enhancer
 
-Chrome extension that generates ultra-enhanced prompts for images using Google's Gemini API. When you click an image, a popup offers **Show** and **Copy** actions, and a side panel tracks your click history.
+Chrome extension that generates ultra‑enhanced prompts for images using Google's Gemini API. Hover over any image to reveal a **View Prompt** button and the prompt appears in the side panel, which also tracks your history.
 
 ## Installation
 
@@ -11,10 +11,9 @@ Chrome extension that generates ultra-enhanced prompts for images using Google's
 
 ## Usage
 
-- Click any image on a webpage to display the popup.
-- **Show**: fetches a prompt from the Gemini API and displays it.
-- **Copy**: copies the generated prompt to your clipboard. The prompt dialog also includes a copy button for convenience.
-- The side panel opens after the first image click, showing thumbnails, generated prompts, and timestamps. Use **Clear History** to remove stored entries.
+- Hover over any image to show the **View Prompt** button.
+- Click **View Prompt** to send the image to the Gemini API and open the side panel.
+- The side panel lists each image with its generated prompt, timestamp and a **Copy** button. Use **Clear History** to remove stored entries.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Chrome extension that generates ultra-enhanced prompts for images using Google's
 - Click any image on a webpage to display the popup.
 - **Show**: fetches a prompt from the Gemini API and displays it.
 - **Copy**: copies the generated prompt to your clipboard. The prompt dialog also includes a copy button for convenience.
-- The side panel opens after the first image click, showing thumbnails and timestamps. Use **Clear History** to remove stored entries.
+- The side panel opens after the first image click, showing thumbnails, generated prompts, and timestamps. Use **Clear History** to remove stored entries.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chrome extension that generates ultra-enhanced prompts for images using Google's
 
 - Click any image on a webpage to display the popup.
 - **Show**: fetches a prompt from the Gemini API and displays it.
-- **Copy**: copies the generated prompt to your clipboard.
+- **Copy**: copies the generated prompt to your clipboard. The prompt dialog also includes a copy button for convenience.
 - The side panel opens after the first image click, showing thumbnails and timestamps. Use **Clear History** to remove stored entries.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Click-to-Prompt-copy
+# Image Prompt Enhancer
+
+Chrome extension that generates ultra-enhanced prompts for images using Google's Gemini API. When you click an image, a popup offers **Show** and **Copy** actions, and a side panel tracks your click history.
+
+## Installation
+
+1. Open Chrome and navigate to `chrome://extensions/`.
+2. Enable **Developer mode** (toggle in the top right).
+3. Click **Load unpacked** and select this project folder.
+4. The extension installs immediately.
+
+## Usage
+
+- Click any image on a webpage to display the popup.
+- **Show**: fetches a prompt from the Gemini API and displays it.
+- **Copy**: copies the generated prompt to your clipboard.
+- The side panel opens after the first image click, showing thumbnails and timestamps. Use **Clear History** to remove stored entries.
+
+## Development
+
+All scripts are plain JavaScript with a dark theme for UI components. API interactions occur in `service_worker.js` using the provided Gemini API key.

--- a/content.css
+++ b/content.css
@@ -1,73 +1,14 @@
-.ctp-popup {
+#ctp-view-btn {
   position: absolute;
   background: #333;
+  color: #fff;
   border: 1px solid #555;
   border-radius: 4px;
-  padding: 4px;
-  z-index: 2147483647;
-  display: flex;
-  gap: 4px;
-}
-
-.ctp-popup button {
-  background: #444;
-  color: #fff;
-  border: none;
   padding: 4px 8px;
-  cursor: pointer;
-}
-
-.ctp-popup button:hover {
-  background: #555;
-}
-
-.ctp-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 2147483647;
-}
-
-.ctp-modal-content {
-  background: #222;
-  color: #fff;
-  padding: 20px;
-  max-width: 80%;
-  max-height: 80%;
-  overflow: auto;
-  border-radius: 8px;
-}
-
-.ctp-modal-content img {
-  max-width: 100%;
-  display: block;
-  margin-bottom: 10px;
-}
-
-.ctp-modal-content pre {
-  white-space: pre-wrap;
-}
-
-.ctp-modal-actions {
-  display: flex;
-  gap: 10px;
-  margin-top: 10px;
-}
-
-.ctp-modal-actions button {
-  background: #444;
-  color: #fff;
-  border: none;
-  padding: 6px 12px;
   cursor: pointer;
 }
 
-.ctp-modal-actions button:hover {
-  background: #555;
+#ctp-view-btn:hover {
+  background: #444;
 }

--- a/content.css
+++ b/content.css
@@ -1,0 +1,58 @@
+.ctp-popup {
+  position: absolute;
+  background: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 4px;
+  z-index: 2147483647;
+  display: flex;
+  gap: 4px;
+}
+
+.ctp-popup button {
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.ctp-popup button:hover {
+  background: #555;
+}
+
+.ctp-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2147483647;
+}
+
+.ctp-modal-content {
+  background: #222;
+  color: #fff;
+  padding: 20px;
+  max-width: 80%;
+  max-height: 80%;
+  overflow: auto;
+  border-radius: 8px;
+}
+
+#ctp-close {
+  margin-top: 10px;
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+#ctp-close:hover {
+  background: #555;
+}

--- a/content.css
+++ b/content.css
@@ -44,6 +44,16 @@
   border-radius: 8px;
 }
 
+.ctp-modal-content img {
+  max-width: 100%;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.ctp-modal-content pre {
+  white-space: pre-wrap;
+}
+
 .ctp-modal-actions {
   display: flex;
   gap: 10px;

--- a/content.css
+++ b/content.css
@@ -44,8 +44,13 @@
   border-radius: 8px;
 }
 
-#ctp-close {
+.ctp-modal-actions {
+  display: flex;
+  gap: 10px;
   margin-top: 10px;
+}
+
+.ctp-modal-actions button {
   background: #444;
   color: #fff;
   border: none;
@@ -53,6 +58,6 @@
   cursor: pointer;
 }
 
-#ctp-close:hover {
+.ctp-modal-actions button:hover {
   background: #555;
 }

--- a/content.js
+++ b/content.js
@@ -1,78 +1,46 @@
-const promptCache = new Map();
-let popup;
+let viewBtn;
+let activeImg;
 
-function handleImageClick(event) {
-  const img = event.target.closest('img');
-  if (!img) return;
-  event.preventDefault();
-  createPopup(img);
-  chrome.runtime.sendMessage({ type: 'recordClick', src: img.src });
-}
-
-document.addEventListener('click', handleImageClick);
-
-function createPopup(img) {
-  removePopup();
-  popup = document.createElement('div');
-  popup.id = 'ctp-popup';
-  popup.className = 'ctp-popup';
-
-  const showBtn = document.createElement('button');
-  showBtn.textContent = 'Show';
-  const copyBtn = document.createElement('button');
-  copyBtn.textContent = 'Copy';
-
-  popup.appendChild(showBtn);
-  popup.appendChild(copyBtn);
-  document.body.appendChild(popup);
-
+function showButton(img) {
+  removeButton();
+  activeImg = img;
+  viewBtn = document.createElement('button');
+  viewBtn.id = 'ctp-view-btn';
+  viewBtn.textContent = 'View Prompt';
+  document.body.appendChild(viewBtn);
   const rect = img.getBoundingClientRect();
-  popup.style.top = `${rect.bottom + window.scrollY}px`;
-  popup.style.left = `${rect.left + window.scrollX}px`;
-
-  showBtn.addEventListener('click', () => {
-    getPrompt(img.src).then(prompt => displayPrompt(prompt, img.src));
-  });
-
-  copyBtn.addEventListener('click', () => {
-    getPrompt(img.src).then(prompt => navigator.clipboard.writeText(prompt));
+  viewBtn.style.top = `${rect.top + window.scrollY + 5}px`;
+  viewBtn.style.left = `${rect.left + window.scrollX + 5}px`;
+  viewBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    chrome.runtime.sendMessage({ type: 'generatePrompt', src: img.src });
+    removeButton();
   });
 }
 
-function removePopup() {
-  if (popup) popup.remove();
-}
-
-function getPrompt(src) {
-  if (promptCache.has(src)) {
-    return Promise.resolve(promptCache.get(src));
+function removeButton() {
+  if (viewBtn) {
+    viewBtn.remove();
+    viewBtn = null;
+    activeImg = null;
   }
-  return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage({ type: 'getPrompt', src }, response => {
-      if (response && response.prompt) {
-        promptCache.set(src, response.prompt);
-        resolve(response.prompt);
-      } else {
-        reject('No prompt');
-      }
-    });
-  });
 }
 
-function displayPrompt(text, src) {
-  const modal = document.createElement('div');
-  modal.className = 'ctp-modal';
-  modal.innerHTML = `
-    <div class="ctp-modal-content">
-      <img src="${src}" alt="clicked image" />
-      <pre>${text}</pre>
-      <div class="ctp-modal-actions">
-        <button id="ctp-copy">Copy</button>
-        <button id="ctp-close">Close</button>
-      </div>
-    </div>
-  `;
-  document.body.appendChild(modal);
-  modal.querySelector('#ctp-close').addEventListener('click', () => modal.remove());
-  modal.querySelector('#ctp-copy').addEventListener('click', () => navigator.clipboard.writeText(text));
-}
+document.addEventListener('mouseover', e => {
+  const img = e.target.closest('img');
+  if (!img) return;
+  showButton(img);
+});
+
+document.addEventListener('mousemove', e => {
+  if (!viewBtn || !activeImg) return;
+  const rect = activeImg.getBoundingClientRect();
+  const btnRect = viewBtn.getBoundingClientRect();
+  const x = e.clientX;
+  const y = e.clientY;
+  const insideImage = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+  const insideBtn = x >= btnRect.left && x <= btnRect.right && y >= btnRect.top && y <= btnRect.bottom;
+  if (!insideImage && !insideBtn) {
+    removeButton();
+  }
+});

--- a/content.js
+++ b/content.js
@@ -31,7 +31,7 @@ function createPopup(img) {
   popup.style.left = `${rect.left + window.scrollX}px`;
 
   showBtn.addEventListener('click', () => {
-    getPrompt(img.src).then(prompt => displayPrompt(prompt));
+    getPrompt(img.src).then(prompt => displayPrompt(prompt, img.src));
   });
 
   copyBtn.addEventListener('click', () => {
@@ -59,11 +59,12 @@ function getPrompt(src) {
   });
 }
 
-function displayPrompt(text) {
+function displayPrompt(text, src) {
   const modal = document.createElement('div');
   modal.className = 'ctp-modal';
   modal.innerHTML = `
     <div class="ctp-modal-content">
+      <img src="${src}" alt="clicked image" />
       <pre>${text}</pre>
       <div class="ctp-modal-actions">
         <button id="ctp-copy">Copy</button>

--- a/content.js
+++ b/content.js
@@ -62,7 +62,12 @@ function getPrompt(src) {
 function displayPrompt(text) {
   const modal = document.createElement('div');
   modal.className = 'ctp-modal';
-  modal.innerHTML = `\n    <div class="ctp-modal-content">\n      <pre>${text}</pre>\n      <button id="ctp-close">Close<\/button>\n    <\/div>\n  `;
+  modal.innerHTML = `
+    <div class="ctp-modal-content">
+      <pre>${text}</pre>
+      <button id="ctp-close">Close</button>
+    </div>
+  `;
   document.body.appendChild(modal);
   modal.querySelector('#ctp-close').addEventListener('click', () => modal.remove());
 }

--- a/content.js
+++ b/content.js
@@ -1,0 +1,68 @@
+const promptCache = new Map();
+let popup;
+
+function handleImageClick(event) {
+  const img = event.target.closest('img');
+  if (!img) return;
+  event.preventDefault();
+  createPopup(img);
+  chrome.runtime.sendMessage({ type: 'recordClick', src: img.src });
+}
+
+document.addEventListener('click', handleImageClick);
+
+function createPopup(img) {
+  removePopup();
+  popup = document.createElement('div');
+  popup.id = 'ctp-popup';
+  popup.className = 'ctp-popup';
+
+  const showBtn = document.createElement('button');
+  showBtn.textContent = 'Show';
+  const copyBtn = document.createElement('button');
+  copyBtn.textContent = 'Copy';
+
+  popup.appendChild(showBtn);
+  popup.appendChild(copyBtn);
+  document.body.appendChild(popup);
+
+  const rect = img.getBoundingClientRect();
+  popup.style.top = `${rect.bottom + window.scrollY}px`;
+  popup.style.left = `${rect.left + window.scrollX}px`;
+
+  showBtn.addEventListener('click', () => {
+    getPrompt(img.src).then(prompt => displayPrompt(prompt));
+  });
+
+  copyBtn.addEventListener('click', () => {
+    getPrompt(img.src).then(prompt => navigator.clipboard.writeText(prompt));
+  });
+}
+
+function removePopup() {
+  if (popup) popup.remove();
+}
+
+function getPrompt(src) {
+  if (promptCache.has(src)) {
+    return Promise.resolve(promptCache.get(src));
+  }
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({ type: 'getPrompt', src }, response => {
+      if (response && response.prompt) {
+        promptCache.set(src, response.prompt);
+        resolve(response.prompt);
+      } else {
+        reject('No prompt');
+      }
+    });
+  });
+}
+
+function displayPrompt(text) {
+  const modal = document.createElement('div');
+  modal.className = 'ctp-modal';
+  modal.innerHTML = `\n    <div class="ctp-modal-content">\n      <pre>${text}</pre>\n      <button id="ctp-close">Close<\/button>\n    <\/div>\n  `;
+  document.body.appendChild(modal);
+  modal.querySelector('#ctp-close').addEventListener('click', () => modal.remove());
+}

--- a/content.js
+++ b/content.js
@@ -65,9 +65,13 @@ function displayPrompt(text) {
   modal.innerHTML = `
     <div class="ctp-modal-content">
       <pre>${text}</pre>
-      <button id="ctp-close">Close</button>
+      <div class="ctp-modal-actions">
+        <button id="ctp-copy">Copy</button>
+        <button id="ctp-close">Close</button>
+      </div>
     </div>
   `;
   document.body.appendChild(modal);
   modal.querySelector('#ctp-close').addEventListener('click', () => modal.remove());
+  modal.querySelector('#ctp-copy').addEventListener('click', () => navigator.clipboard.writeText(text));
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Image Prompt Enhancer",
+  "version": "1.0.0",
+  "description": "Generate ultra-enhanced prompts for clicked images using the Gemini API.",
+  "permissions": ["activeTab", "sidePanel", "storage"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "service_worker.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["content.css"]
+    }
+  ],
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Image Prompt Enhancer",
   "version": "1.0.0",
-  "description": "Generate ultra-enhanced prompts for clicked images using the Gemini API.",
+  "description": "Generate ultra-enhanced prompts for images using the Gemini API.",
   "permissions": ["activeTab", "sidePanel", "storage"],
   "host_permissions": ["<all_urls>"],
   "background": {

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,0 +1,47 @@
+const API_KEY = 'AIzaSyC9FJNjsqjuxWYKQ2Olh3OtYjHVYQbADtc';
+let panelOpened = false;
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ history: [] });
+});
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'getPrompt') {
+    fetchPrompt(msg.src)
+      .then(prompt => sendResponse({ prompt }))
+      .catch(() => sendResponse({ prompt: 'Error generating prompt.' }));
+    return true;
+  }
+  if (msg.type === 'recordClick') {
+    saveHistory(msg.src);
+    if (!panelOpened && sender.tab) {
+      chrome.sidePanel.open({ windowId: sender.tab.windowId });
+      panelOpened = true;
+    }
+  }
+});
+
+async function fetchPrompt(imageUrl) {
+  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{
+        parts: [
+          { text: 'Provide an ultra-enhanced prompt for this image.' },
+          { image_url: imageUrl }
+        ]
+      }]
+    })
+  });
+  const data = await res.json();
+  return data?.candidates?.[0]?.content?.parts?.[0]?.text || 'No prompt generated.';
+}
+
+function saveHistory(src) {
+  const item = { src, time: Date.now() };
+  chrome.storage.local.get({ history: [] }, res => {
+    res.history.push(item);
+    chrome.storage.local.set({ history: res.history });
+  });
+}

--- a/service_worker.js
+++ b/service_worker.js
@@ -6,31 +6,27 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.type === 'getPrompt') {
+  if (msg.type === 'generatePrompt') {
     chrome.storage.local.get({ history: [] }, async res => {
       const existing = res.history.find(item => item.src === msg.src && item.prompt);
+      let prompt;
       if (existing) {
-        sendResponse({ prompt: existing.prompt });
+        prompt = existing.prompt;
       } else {
         try {
-          const prompt = await fetchPrompt(msg.src);
+          prompt = await fetchPrompt(msg.src);
           saveHistory(msg.src, prompt);
-          sendResponse({ prompt });
         } catch (e) {
-          sendResponse({ prompt: 'Error generating prompt.' });
+          prompt = 'Error generating prompt.';
         }
       }
-    });
-    return true;
-  }
-  if (msg.type === 'recordClick') {
-    fetchPrompt(msg.src).then(prompt => {
-      saveHistory(msg.src, prompt);
       if (!panelOpened && sender.tab) {
         chrome.sidePanel.open({ windowId: sender.tab.windowId });
         panelOpened = true;
       }
+      sendResponse({ prompt });
     });
+    return true;
   }
 });
 

--- a/service_worker.js
+++ b/service_worker.js
@@ -28,7 +28,7 @@ async function fetchPrompt(imageUrl) {
   const arrayBuf = await imgRes.arrayBuffer();
   const base64 = arrayBufferToBase64(arrayBuf);
 
-  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${API_KEY}`, {
+    const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.0-pro-vision:generateContent?key=${API_KEY}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/service_worker.js
+++ b/service_worker.js
@@ -22,6 +22,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 });
 
 async function fetchPrompt(imageUrl) {
+  // Fetch the image and convert to base64 so the Gemini API can read it.
+  const imgRes = await fetch(imageUrl);
+  const mimeType = imgRes.headers.get('content-type') || 'image/png';
+  const arrayBuf = await imgRes.arrayBuffer();
+  const base64 = arrayBufferToBase64(arrayBuf);
+
   const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${API_KEY}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -29,13 +35,20 @@ async function fetchPrompt(imageUrl) {
       contents: [{
         parts: [
           { text: 'Provide an ultra-enhanced prompt for this image.' },
-          { image_url: imageUrl }
+          { inline_data: { mime_type: mimeType, data: base64 } }
         ]
       }]
     })
   });
   const data = await res.json();
   return data?.candidates?.[0]?.content?.parts?.[0]?.text || 'No prompt generated.';
+}
+
+function arrayBufferToBase64(buffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  bytes.forEach(b => (binary += String.fromCharCode(b)));
+  return btoa(binary);
 }
 
 function saveHistory(src) {

--- a/service_worker.js
+++ b/service_worker.js
@@ -7,17 +7,30 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'getPrompt') {
-    fetchPrompt(msg.src)
-      .then(prompt => sendResponse({ prompt }))
-      .catch(() => sendResponse({ prompt: 'Error generating prompt.' }));
+    chrome.storage.local.get({ history: [] }, async res => {
+      const existing = res.history.find(item => item.src === msg.src && item.prompt);
+      if (existing) {
+        sendResponse({ prompt: existing.prompt });
+      } else {
+        try {
+          const prompt = await fetchPrompt(msg.src);
+          saveHistory(msg.src, prompt);
+          sendResponse({ prompt });
+        } catch (e) {
+          sendResponse({ prompt: 'Error generating prompt.' });
+        }
+      }
+    });
     return true;
   }
   if (msg.type === 'recordClick') {
-    saveHistory(msg.src);
-    if (!panelOpened && sender.tab) {
-      chrome.sidePanel.open({ windowId: sender.tab.windowId });
-      panelOpened = true;
-    }
+    fetchPrompt(msg.src).then(prompt => {
+      saveHistory(msg.src, prompt);
+      if (!panelOpened && sender.tab) {
+        chrome.sidePanel.open({ windowId: sender.tab.windowId });
+        panelOpened = true;
+      }
+    });
   }
 });
 
@@ -51,8 +64,8 @@ function arrayBufferToBase64(buffer) {
   return btoa(binary);
 }
 
-function saveHistory(src) {
-  const item = { src, time: Date.now() };
+function saveHistory(src, prompt) {
+  const item = { src, prompt, time: Date.now() };
   chrome.storage.local.get({ history: [] }, res => {
     res.history.push(item);
     chrome.storage.local.set({ history: res.history });

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Click History</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Click History</h1>
+  <button id="clear">Clear History</button>
+  <ul id="history"></ul>
+  <script src="sidepanel.js"></script>
+</body>
+</html>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Click History</title>
+  <title>Prompt History</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Click History</h1>
+  <h1>Prompt History</h1>
   <button id="clear">Clear History</button>
   <ul id="history"></ul>
   <script src="sidepanel.js"></script>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6,10 +6,17 @@ function renderHistory() {
       const li = document.createElement('li');
       const img = document.createElement('img');
       img.src = item.src;
+      const info = document.createElement('div');
+      info.className = 'info';
+      const p = document.createElement('p');
+      p.className = 'prompt';
+      p.textContent = item.prompt || '';
       const span = document.createElement('span');
       span.textContent = new Date(item.time).toLocaleString();
+      info.appendChild(p);
+      info.appendChild(span);
       li.appendChild(img);
-      li.appendChild(span);
+      li.appendChild(info);
       list.appendChild(li);
     });
   });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1,0 +1,28 @@
+function renderHistory() {
+  chrome.storage.local.get({ history: [] }, res => {
+    const list = document.getElementById('history');
+    list.innerHTML = '';
+    res.history.forEach(item => {
+      const li = document.createElement('li');
+      const img = document.createElement('img');
+      img.src = item.src;
+      const span = document.createElement('span');
+      span.textContent = new Date(item.time).toLocaleString();
+      li.appendChild(img);
+      li.appendChild(span);
+      list.appendChild(li);
+    });
+  });
+}
+
+document.getElementById('clear').addEventListener('click', () => {
+  chrome.storage.local.set({ history: [] }, renderHistory);
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.history) {
+    renderHistory();
+  }
+});
+
+renderHistory();

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2,7 +2,7 @@ function renderHistory() {
   chrome.storage.local.get({ history: [] }, res => {
     const list = document.getElementById('history');
     list.innerHTML = '';
-    res.history.forEach(item => {
+    res.history.slice().reverse().forEach(item => {
       const li = document.createElement('li');
       const img = document.createElement('img');
       img.src = item.src;
@@ -13,8 +13,13 @@ function renderHistory() {
       p.textContent = item.prompt || '';
       const span = document.createElement('span');
       span.textContent = new Date(item.time).toLocaleString();
+      const copyBtn = document.createElement('button');
+      copyBtn.className = 'copy';
+      copyBtn.textContent = 'Copy';
+      copyBtn.addEventListener('click', () => navigator.clipboard.writeText(item.prompt || ''));
       info.appendChild(p);
       info.appendChild(span);
+      info.appendChild(copyBtn);
       li.appendChild(img);
       li.appendChild(info);
       list.appendChild(li);

--- a/styles.css
+++ b/styles.css
@@ -49,9 +49,24 @@ h1 {
 #history .prompt {
   font-size: 12px;
   margin: 0 0 4px 0;
+  white-space: pre-wrap;
 }
 
 #history span {
   font-size: 11px;
   color: #bbb;
+}
+
+#history .copy {
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 4px 6px;
+  cursor: pointer;
+  margin-top: 4px;
+  align-self: flex-start;
+}
+
+#history .copy:hover {
+  background: #444;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,47 @@
+body {
+  background: #121212;
+  color: #e0e0e0;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 10px;
+}
+
+h1 {
+  font-size: 18px;
+  margin-top: 0;
+}
+
+#clear {
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  cursor: pointer;
+  margin-bottom: 10px;
+}
+
+#clear:hover {
+  background: #444;
+}
+
+#history {
+  list-style: none;
+  padding: 0;
+}
+
+#history li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+#history img {
+  max-width: 40px;
+  max-height: 40px;
+  margin-right: 8px;
+}
+
+#history span {
+  font-size: 12px;
+  color: #bbb;
+}

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@ h1 {
 
 #history li {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 8px;
 }
 
@@ -41,7 +41,17 @@ h1 {
   margin-right: 8px;
 }
 
-#history span {
+#history .info {
+  display: flex;
+  flex-direction: column;
+}
+
+#history .prompt {
   font-size: 12px;
+  margin: 0 0 4px 0;
+}
+
+#history span {
+  font-size: 11px;
   color: #bbb;
 }


### PR DESCRIPTION
## Summary
- add Manifest V3 extension that injects buttons on image click and opens a side panel history
- implement service worker with Gemini API calls and click tracking
- style popup and side panel with dark theme and provide installation instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d2bf7fa08331be7abfa0b0479262