### PR TITLE
Add Chrome extension for image-to-text prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Click-to-Prompt-copy
+# Click to Prompt
+
+A Chrome extension that converts images to text prompts using [Tesseract.js](https://tesseract.projectnaptha.com/). Hover over an image on any page to reveal a **View Prompt** button. Clicking it runs OCR and displays the extracted text in a sidebar with options to copy or clear the result.
+
+## Installation
+1. Open `chrome://extensions/` in Chrome.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+
+## Usage
+Hover over an image and click **View Prompt** to extract the text. The recognized text appears in the sidebar; use the Copy or Clear buttons as needed.
+
+A standalone prototype (`index.html`) is included for reference.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,89 @@
+(function() {
+  // Inject Tesseract.js
+  const tScript = document.createElement('script');
+  tScript.src = 'https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js';
+  tScript.onload = initOverlay;
+  document.head.appendChild(tScript);
+
+  function initOverlay() {
+    const btn = document.createElement('button');
+    btn.id = 'ctp-view-prompt-btn';
+    btn.textContent = 'View Prompt';
+    document.body.appendChild(btn);
+
+    const sidebar = document.createElement('aside');
+    sidebar.id = 'ctp-prompt-sidebar';
+    sidebar.classList.add('hidden');
+    sidebar.innerHTML = `
+      <div class="ctp-sidebar-header">
+        <h2>Prompt</h2>
+        <button id="ctp-close-sidebar" aria-label="Close sidebar">&times;</button>
+      </div>
+      <pre id="ctp-prompt-output" class="ctp-prompt-output"></pre>
+      <div class="ctp-sidebar-actions">
+        <button id="ctp-copy-prompt">Copy</button>
+        <button id="ctp-clear-prompt">Clear</button>
+      </div>`;
+    document.body.appendChild(sidebar);
+
+    const output = document.getElementById('ctp-prompt-output');
+    const closeSidebar = document.getElementById('ctp-close-sidebar');
+    const copyPrompt = document.getElementById('ctp-copy-prompt');
+    const clearPrompt = document.getElementById('ctp-clear-prompt');
+    let currentImg = null;
+
+    document.addEventListener('mouseover', (e) => {
+      if (e.target.tagName === 'IMG') {
+        currentImg = e.target;
+        const rect = currentImg.getBoundingClientRect();
+        btn.style.top = `${window.scrollY + rect.top + rect.height / 2}px`;
+        btn.style.left = `${window.scrollX + rect.left + rect.width / 2}px`;
+        btn.classList.add('visible');
+      }
+    });
+
+    document.addEventListener('mouseout', (e) => {
+      if (e.target.tagName === 'IMG') {
+        setTimeout(() => {
+          if (!btn.matches(':hover')) {
+            btn.classList.remove('visible');
+          }
+        }, 200);
+      }
+    });
+
+    btn.addEventListener('mouseleave', () => {
+      btn.classList.remove('visible');
+    });
+
+    btn.addEventListener('click', async () => {
+      if (!currentImg) return;
+      sidebar.classList.remove('hidden');
+      output.textContent = 'Processing...';
+      try {
+        const result = await Tesseract.recognize(currentImg.src, 'eng', { logger: m => console.log(m) });
+        output.textContent = result.data.text.trim() || 'No text found.';
+      } catch (err) {
+        output.textContent = 'Error extracting text.';
+        console.error(err);
+      }
+    });
+
+    copyPrompt.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(output.textContent);
+        alert('Prompt copied to clipboard');
+      } catch (err) {
+        alert('Failed to copy');
+      }
+    });
+
+    clearPrompt.addEventListener('click', () => {
+      output.textContent = '';
+    });
+
+    closeSidebar.addEventListener('click', () => {
+      sidebar.classList.add('hidden');
+    });
+  }
+})();

--- a/contentStyles.css
+++ b/contentStyles.css
@@ -1,0 +1,51 @@
+#ctp-view-prompt-btn {
+  position: absolute;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: none;
+  z-index: 2147483647;
+}
+#ctp-view-prompt-btn.visible {
+  display: block;
+}
+
+#ctp-prompt-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  max-width: 100%;
+  height: 100%;
+  background: #f9f9f9;
+  border-left: 1px solid #ccc;
+  padding: 1rem;
+  z-index: 2147483647;
+  box-shadow: -2px 0 4px rgba(0, 0, 0, 0.2);
+}
+#ctp-prompt-sidebar.hidden {
+  display: none;
+}
+
+.ctp-sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ctp-sidebar-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ctp-prompt-output {
+  white-space: pre-wrap;
+  background: #fff;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  height: 200px;
+  overflow-y: auto;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image to Prompt Tool</title>
+  <link rel="stylesheet" href="styles.css" />
+  <!-- Tesseract.js CDN for OCR -->
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Image to Prompt Tool</h1>
+  </header>
+  <main>
+    <section class="image-section">
+      <label for="imageUpload" class="upload-label">Upload Image</label>
+      <input type="file" id="imageUpload" accept="image/*" />
+      <div class="image-container">
+        <img id="previewImage" src="https://via.placeholder.com/400x300.png?text=Upload+Image" alt="Preview" />
+        <button id="viewPromptBtn" class="prompt-btn">View Prompt</button>
+      </div>
+    </section>
+    <aside id="promptSidebar" class="sidebar hidden">
+      <div class="sidebar-header">
+        <h2>Prompt</h2>
+        <button id="closeSidebar" aria-label="Close sidebar">&times;</button>
+      </div>
+      <pre id="promptOutput" class="prompt-output"></pre>
+      <div class="sidebar-actions">
+        <button id="copyPrompt">Copy</button>
+        <button id="clearPrompt">Clear</button>
+      </div>
+    </aside>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Click to Prompt",
+  "version": "0.1",
+  "description": "Hover over images to extract text with a sidebar prompt viewer.",
+  "permissions": ["clipboardWrite"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "css": ["contentStyles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,55 @@
+const imageUpload = document.getElementById('imageUpload');
+const previewImage = document.getElementById('previewImage');
+const viewPromptBtn = document.getElementById('viewPromptBtn');
+const promptSidebar = document.getElementById('promptSidebar');
+const promptOutput = document.getElementById('promptOutput');
+const copyPrompt = document.getElementById('copyPrompt');
+const clearPrompt = document.getElementById('clearPrompt');
+const closeSidebar = document.getElementById('closeSidebar');
+
+// Preview uploaded image
+imageUpload.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    previewImage.src = event.target.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+// Extract text from image using Tesseract.js
+viewPromptBtn.addEventListener('click', async () => {
+  if (!previewImage.src) return;
+  promptOutput.textContent = 'Processing...';
+  promptSidebar.classList.remove('hidden');
+  try {
+    const result = await Tesseract.recognize(previewImage.src, 'eng', {
+      logger: (m) => console.log(m)
+    });
+    promptOutput.textContent = result.data.text.trim() || 'No text found.';
+  } catch (err) {
+    promptOutput.textContent = 'Error extracting text.';
+    console.error(err);
+  }
+});
+
+// Copy prompt to clipboard
+copyPrompt.addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText(promptOutput.textContent);
+    alert('Prompt copied to clipboard');
+  } catch (err) {
+    alert('Failed to copy');
+  }
+});
+
+// Clear prompt output
+clearPrompt.addEventListener('click', () => {
+  promptOutput.textContent = '';
+});
+
+// Close sidebar
+closeSidebar.addEventListener('click', () => {
+  promptSidebar.classList.add('hidden');
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,81 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+header {
+  background: #4a90e2;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+main {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+}
+.image-section {
+  flex: 1;
+  padding: 1rem;
+}
+.upload-label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+.image-container {
+  position: relative;
+  display: inline-block;
+}
+.image-container img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+.prompt-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.image-container:hover .prompt-btn {
+  opacity: 1;
+}
+.sidebar {
+  width: 300px;
+  max-width: 100%;
+  border-left: 1px solid #ccc;
+  padding: 1rem;
+  background: #f9f9f9;
+  position: relative;
+}
+.sidebar.hidden {
+  display: none;
+}
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.sidebar-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.prompt-output {
+  white-space: pre-wrap;
+  background: #fff;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  height: 200px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Provide a Manifest V3 Chrome extension that overlays a View Prompt button on images and shows OCR text in a sidebar
- Implement content script with Tesseract.js and styles for button and sidebar
- Document installation and usage instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e6955c108331b1f3dcc72c6ad7fc